### PR TITLE
Make 'Type' dropdown function when a new section is added.

### DIFF
--- a/apps/sections/templates/admin/pages/page/sections.js
+++ b/apps/sections/templates/admin/pages/page/sections.js
@@ -5,7 +5,7 @@ $(window).load(function() {
 
   $sections.find('.field-type select').change(renderSectionFields);
 
-  $(document).on("change", "[class^=dynamic-][class$=section_set] .field-type select", renderSectionFields);
+  $(document).on("change", "[class*=section_set] .field-type select", renderSectionFields);
   // As jQuery event bindings are 'first come first served',
   // showHideSectionFields will be called after the default 'add another
   // section' handler is called. So this will work!


### PR DESCRIPTION
The selector for finding the 'Type' dropdown is incorrect, and so the event handler to the document `change` event is not fired. Consequently, fields are not shown/hidden when a section is added inline with 'Add another content section'.

This commit fixes it by using a derivative of the a selector used elsewhere in the JS to find section inlines (`[class*=section_set]`).
